### PR TITLE
更新chimee-helper的来源

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/Chimeejs/chimee-plugin-controlbar#readme",
   "dependencies": {
     "babel-eslint": "^9.0.0",
-    "chimee-helper": "git+https://github.com/Chimeejs/chimee-helper.git"
+    "chimee-helper": "^0.2.11"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
先多谢chimee提供播放器！

之前依赖的chimee-helper是指定的git地址，目前我们内部的构建环境只能访问npm仓库，所以希望能修改一下，多谢！